### PR TITLE
Keep SniffAir from crashing during EAP import

### DIFF
--- a/lib/Sniffer.py
+++ b/lib/Sniffer.py
@@ -97,10 +97,15 @@ class packet_sniffer():
 				sql.Insert_Probe_RESPONSE(SSID, MAC, Vendor, CHL, SIG, ENC, CHR, ATH, RPCM)
 			
 		if pkt.haslayer(EAP):
-			if pkt[EAP].id == 1:
-				if len(pkt[EAP].identity) > 0:
-					self.EAP_Identity(pkt)
-                    			sql.Insert_EAP(sender, user, ap)
+			if pkt[EAP].id == 1 and pkt[EAP].code == 2:
+				try:
+					if len(pkt[EAP].identity) > 0:
+						self.EAP_Identity(pkt)
+						sql.Insert_EAP(sender, user, ap)
+				except TypeError:
+					print "\n" + RD + "[+]"+ NRM +" An error has occurred"
+					print pkt.show()
+					os.kill(os.getpid(), signal.SIGINT)
  		
 
 	def Vendor(self, pkt):


### PR DESCRIPTION
While importing a pcap file, SniffAir would crash when trying to parse a
Request, Identity packet. What we are looking for are Response, Identity
packets. Both packets contained the Type: Identity (1); however, The
Code: for Request is 1 and 2 for Response. This commit will look for the
Code: 2.

I've also added an exception catch to dump the packet that causes the
error and exits the import.